### PR TITLE
Include string in Main.cpp

### DIFF
--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -2,6 +2,7 @@
 #include <iostream>
 #include <filesystem>
 #include <fstream>
+#include <string>
 #include "Inject.h"
 
 namespace fs = std::filesystem;


### PR DESCRIPTION
This is so that the Visual Studio compiler can work, as for some reason it needs string to be directly included, but not mingw